### PR TITLE
Increase PHPUnit verbosity

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     bootstrap="vendor/autoload.php"
     colors="true"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
 >
   <testsuite name="Test Suite">


### PR DESCRIPTION
To ensure that any notices, errors, and warnings, etc, are clearly visible, this PR sets the relevant configuration item in the default PHPUnit configuration file.